### PR TITLE
Fix backbuffer copying that are typeless by converting them to unorm

### DIFF
--- a/Pictomancy/DXDraw/FormatExtensions.cs
+++ b/Pictomancy/DXDraw/FormatExtensions.cs
@@ -1,0 +1,27 @@
+using Format = SharpDX.DXGI.Format;
+
+namespace Pictomancy.DXDraw;
+
+internal static class FormatExtensions
+{
+    public static Format ToUNorm(this Format format)
+    {
+        return format switch
+        {
+            Format.R8_Typeless => Format.R8_UNorm,
+            Format.R8G8_Typeless => Format.R8G8_UNorm,
+            Format.R8G8B8A8_Typeless => Format.R8G8B8A8_UNorm,
+            Format.R16_Typeless => Format.R16_UNorm,
+            Format.R16G16_Typeless => Format.R16G16_UNorm,
+            Format.R16G16B16A16_Typeless => Format.R16G16B16A16_UNorm,
+            Format.R10G10B10A2_Typeless => Format.R10G10B10A2_UNorm,
+            Format.B8G8R8A8_Typeless => Format.B8G8R8A8_UNorm,
+            Format.B8G8R8X8_Typeless => Format.B8G8R8X8_UNorm,
+            Format.BC1_Typeless => Format.BC1_UNorm,
+            Format.BC2_Typeless => Format.BC2_UNorm,
+            Format.BC3_Typeless => Format.BC3_UNorm,
+            Format.BC7_Typeless => Format.BC7_UNorm,
+            _ => format,
+        };
+    }
+}

--- a/Pictomancy/DXDraw/RenderTarget.cs
+++ b/Pictomancy/DXDraw/RenderTarget.cs
@@ -141,6 +141,7 @@ internal class RenderTarget : IDisposable
 
             var copyDesc = backBufferDesc;
             copyDesc.BindFlags = BindFlags.ShaderResource;
+            copyDesc.Format = copyDesc.Format.ToUNorm();
             _backBufferCopy = new Texture2D(device, copyDesc);
             _backBufferSRV = new ShaderResourceView(device, _backBufferCopy);
         }

--- a/Pictomancy/DXDraw/UIMaskCapture.cs
+++ b/Pictomancy/DXDraw/UIMaskCapture.cs
@@ -245,6 +245,7 @@ internal unsafe class UIMaskCapture : IDisposable
         snapDesc.CpuAccessFlags = CpuAccessFlags.None;
         snapDesc.OptionFlags    = ResourceOptionFlags.None;
         snapDesc.Usage          = ResourceUsage.Default;
+        snapDesc.Format         = snapDesc.Format.ToUNorm();
 
         _snapshot = new(_ctx.Device, snapDesc);
         _snapshotSRV = new(_ctx.Device, _snapshot);
@@ -297,6 +298,7 @@ internal unsafe class UIMaskCapture : IDisposable
         copyDesc.CpuAccessFlags = CpuAccessFlags.None;
         copyDesc.OptionFlags = ResourceOptionFlags.None;
         copyDesc.Usage = ResourceUsage.Default;
+        copyDesc.Format = copyDesc.Format.ToUNorm();
 
         _bbCopy = new(_ctx.Device, copyDesc);
         _bbCopySRV = new(_ctx.Device, _bbCopy);


### PR DESCRIPTION
Special K (and possibly other tools) can use typeless formats. This is what Special K does internally and should be good enough.

This fixing problems where CreateShaderResources doesn't work when using Special K due to typeless formats in the buffer descriptors that are being copied.